### PR TITLE
Chocolatey as optional on Windows (#1612)

### DIFF
--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -19,7 +19,8 @@ from conans.test.utils.runner import TestRunner
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput
 from conans.test.utils.visual_project_files import get_vs_project_files
-from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool
+from conans.test.utils.context_manager import which
+from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool, ChocolateyTool
 from conans.util.files import save
 
 
@@ -124,10 +125,14 @@ class HelloConan(ConanFile):
     def system_package_tool_fail_when_not_0_returned_test(self):
         runner = RunnerMock(return_ok=False)
         spt = SystemPackageTool(runner=runner)
-        platforms = {"Linux": "sudo apt-get update", "Darwin": "brew update", "Windows": "choco outdated"}
+        platforms = {"Linux": "sudo apt-get update", "Darwin": "brew update"}
         if platform.system() in platforms:
             msg = "Command '%s' failed" % platforms[platform.system()]
             with self.assertRaisesRegexp(ConanException, msg):
+                spt.update()
+        elif platform.system() == "Windows" and which("choco.exe"):
+            spt = SystemPackageTool(runner=runner, tool=ChocolateyTool())
+            with self.assertRaisesRegexp(ConanException, "Command 'choco outdated' failed"):
                 spt.update()
         else:
             spt.update()  # Won't raise anything because won't do anything
@@ -197,16 +202,18 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=False)
         self.assertEquals(runner.command_called, "pkg info a_package")
 
-        os_info.is_freebsd = False
-        os_info.is_windows = True
+        # Chocolatey is an optional package manager on Windows
+        if platform.system() == "Windows" and which("choco.exe"):
+            os_info.is_freebsd = False
+            os_info.is_windows = True
 
-        spt = SystemPackageTool(runner=runner, os_info=os_info)
-        spt.update()
-        self.assertEquals(runner.command_called, "choco outdated")
-        spt.install("a_package", force=True)
-        self.assertEquals(runner.command_called, "choco install --yes a_package")
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+            spt = SystemPackageTool(runner=runner, os_info=os_info, tool=ChocolateyTool())
+            spt.update()
+            self.assertEquals(runner.command_called, "choco outdated")
+            spt.install("a_package", force=True)
+            self.assertEquals(runner.command_called, "choco install --yes a_package")
+            spt.install("a_package", force=False)
+            self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
         os.environ["CONAN_SYSREQUIRES_SUDO"] = "False"
 
@@ -256,16 +263,18 @@ class HelloConan(ConanFile):
         spt.install("a_package", force=True)
         self.assertEquals(runner.command_called, "pkgutil --install --yes a_package")
 
-        os_info.is_solaris = False
-        os_info.is_windows = True
+        # Chocolatey is an optional package manager on Windows
+        if platform.system() == "Windows" and which("choco.exe"):
+            os_info.is_solaris = False
+            os_info.is_windows = True
 
-        spt = SystemPackageTool(runner=runner, os_info=os_info)
-        spt.update()
-        self.assertEquals(runner.command_called, "choco outdated")
-        spt.install("a_package", force=True)
-        self.assertEquals(runner.command_called, "choco install --yes a_package")
-        spt.install("a_package", force=False)
-        self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
+            spt = SystemPackageTool(runner=runner, os_info=os_info, tool=ChocolateyTool())
+            spt.update()
+            self.assertEquals(runner.command_called, "choco outdated")
+            spt.install("a_package", force=True)
+            self.assertEquals(runner.command_called, "choco install --yes a_package")
+            spt.install("a_package", force=False)
+            self.assertEquals(runner.command_called, 'choco search --local-only --exact a_package | findstr /c:"1 packages installed."')
 
         del os.environ["CONAN_SYSREQUIRES_SUDO"]
 
@@ -300,13 +309,16 @@ class HelloConan(ConanFile):
     def system_package_tool_installed_test(self):
         if platform.system() != "Linux" and platform.system() != "Macos" and platform.system() != "Windows":
             return
+        if platform.system() == "Windows" and not which("choco.exe"):
+            return
         spt = SystemPackageTool()
-        if platform.system() == "Windows":
+        expected_package = "git"
+        if platform.system() == "Windows" and which("choco.exe"):
+            spt = SystemPackageTool(tool=ChocolateyTool())
             # Git is not installed by default on Chocolatey
-            self.assertTrue(spt._tool.installed("chocolatey"))
-        else:
-            # Git should be installed on development/testing machines
-            self.assertTrue(spt._tool.installed("git"))
+            expected_package = "chocolatey"
+        # The expected should be installed on development/testing machines
+        self.assertTrue(spt._tool.installed(expected_package))
         # This package hopefully doesn't exist
         self.assertFalse(spt._tool.installed("oidfjgesiouhrgioeurhgielurhgaeiorhgioearhgoaeirhg"))
 

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -623,8 +623,6 @@ class SystemPackageTool(object):
             return PkgTool()
         elif os_info.is_solaris:
             return PkgUtilTool()
-        elif os_info.is_windows:
-            return ChocolateyTool()
         else:
             return NullTool()
 


### PR DESCRIPTION
- Change Chocolatey as optional package manager on Windows. By default,
  Windows uses NullTool (show warning message).

Signed-off-by: Uilian Ries <uilianries@gmail.com>

Changelog: (Feature | Fix | Bugfix): Describe here your pull request

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://raw.githubusercontent.com/conan-io/conan/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 


